### PR TITLE
Fixing error on npm run ios-sim & npm run android-sim

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-react-hello-world",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "An RHMAP Hello World application written using TypeScript and React",
   "main": "index.js",
   "scripts": {
@@ -11,8 +11,8 @@
     "compile": "tsc && npm run bundle-js && npm run vendor-js",
     "bundle-js": "browserify -e src/index.js -o www/bundle.js --no-bundle-external --debug",
     "vendor-js": "browserify -o www/vendor.js -r fh-js-sdk -r fastclick -r react-dom -r react",
-    "ios-sim": "npm run compile && cordova platform add ios ; && cordova run ios --emulator",
-    "android-sim": "npm run compile && cordova platform add android ; cordova run android --emulator"
+    "ios-sim": "npm run compile && cordova platform add ios && cordova run ios --emulator",
+    "android-sim": "npm run compile && cordova platform add android cordova run android --emulator"
   },
   "author": "Evan Shortiss",
   "license": "MIT",


### PR DESCRIPTION
Fixing a small error when running the iOS/Android simulator via `npm run ios-sim`.

Previous error:

```
> npm run compile && cordova platform add ios ; && cordova run ios --emulator

sh: -c: line 0: syntax error near unexpected token `&&'
sh: -c: line 0: `npm run compile && cordova platform add ios ; && cordova run ios --emulator'
```